### PR TITLE
Person class: Use email instead of name for same-person identification

### DIFF
--- a/src/main/java/loopin/projectbook/model/person/Person.java
+++ b/src/main/java/loopin/projectbook/model/person/Person.java
@@ -71,7 +71,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getEmail().equals(getEmail());
     }
 
     /**


### PR DESCRIPTION
Changed identification for same person to email