### PR TITLE
Allow more characters in name and duplicate names

### DIFF
--- a/src/main/java/loopin/projectbook/model/person/Name.java
+++ b/src/main/java/loopin/projectbook/model/person/Name.java
@@ -16,7 +16,8 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    //public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9/.(),]+";
 
     public final String fullName;
 

--- a/src/main/java/loopin/projectbook/model/person/Person.java
+++ b/src/main/java/loopin/projectbook/model/person/Person.java
@@ -78,7 +78,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same phone, email or telegram.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -88,13 +88,11 @@ public class Person {
             return false;
         }
 
-        boolean isSameName = otherPerson.getName().equals(getName());
-        boolean isSameRole = otherPerson.getRole().equals(getRole());
         boolean isSamePhone = otherPerson.getPhone().equals(getPhone());
         boolean isSameEmail = otherPerson.getEmail().equals(getEmail());
         boolean isSameTelegram = otherPerson.getTelegram().equals(getTelegram());
 
-        return (isSameName && isSameRole) || isSamePhone || isSameEmail || isSameTelegram;
+        return isSamePhone || isSameEmail || isSameTelegram;
     }
 
     // Add this method for duplicate checking in RemarkCommand


### PR DESCRIPTION
Names only allow alphanumeric characters.
Same name and same role is not allowed.

Let's,
* allow characters such as () , . / as they may be part of a name
* allow all duplicate names regardless of role

Fixes #119 