### PR TITLE
Finetune code

### DIFF
--- a/src/main/java/loopin/projectbook/logic/Messages.java
+++ b/src/main/java/loopin/projectbook/logic/Messages.java
@@ -20,8 +20,11 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX = "The project index provided is invalid";
-    public static final String MESSAGE_PROJECT_NOT_FOUND_BY_NAME = "No project found with name: %s";
     public static final String MESSAGE_PROJECTS_LISTED_OVERVIEW = "%1$d project(s) listed!";
+    public static final String MESSAGE_NO_PERSON = "Person '%s' does not exist.";
+    public static final String MESSAGE_NO_PROJECT = "Project '%s' does not exist.";
+    public static final String MESSAGE_AMBIGUOUS_NAME = "Multiple people share the name %s.\n"
+            + "Please use index-based commands instead.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/loopin/projectbook/logic/commands/EditCommand.java
+++ b/src/main/java/loopin/projectbook/logic/commands/EditCommand.java
@@ -35,7 +35,17 @@ import loopin.projectbook.model.project.Project;
 
 
 /**
- * Edits the details of an existing person in the project book.
+ * Edits fields of an existing {@link Person} in the project book.
+ *
+ * Usage:
+ * {@code
+ * edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [tg/TELEGRAM] [c/COMMITTEE] [o/ORGANISATION]
+ * }
+ *
+ * Role-specific constraints:
+ *   - {@link TeamMember} cannot edit Organisation.
+ *   - {@link OrgMember} cannot edit Committee.
+ *   - {@link Volunteer} cannot edit role-specific fields (Committee/Organisation).
  */
 public class EditCommand extends Command {
 
@@ -64,8 +74,10 @@ public class EditCommand extends Command {
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
-     * @param editPersonDescriptor details to edit the person with
+     * Constructs an {@code EditCommand}.
+     *
+     * @param index index of the person in the filtered person list to edit
+     * @param editPersonDescriptor details to edit the person with; at least one field must be present
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
@@ -84,6 +96,10 @@ public class EditCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
+        if (!editPersonDescriptor.isAnyFieldEdited()) {
+            throw new CommandException(MESSAGE_NOT_EDITED);
+        }
+
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
@@ -97,57 +113,84 @@ public class EditCommand extends Command {
     }
 
     /**
-     * Creates and returns a new {@code Person} object (or one of its subclasses with updated field values based on
-     * the provided {@code EditPersonDescriptor}.
+     * Creates and returns a new {@link Person} (or subclass) based on {@code original} and {@code edits}.
      *
-     * @param personToEdit the existing {@code Person} to be edited
-     * @param editPersonDescriptor the {@code EditPersonDescriptor} containing optional updated values
-     * @return a new {@code Person} (or subclass) instance with applied edits
-     * @throws CommandException if a field inappropriate for the person’s role is supplied
+     * SLAP steps:
+     *   - Assemble common fields
+     *   - Enforce role-specific constraints
+     *   - Construct the correct subclass
+     *
+     * @param original existing person to edit; must not be {@code null}
+     * @param edits optional updates to apply
+     * @return updated {@link Person}
+     * @throws CommandException if role-specific constraints are violated
      */
-    private static Person createEditedPerson(
-            Person personToEdit, EditPersonDescriptor editPersonDescriptor
-    ) throws CommandException {
-        assert personToEdit != null;
+    private static Person createEditedPerson(Person original, EditPersonDescriptor edits) throws CommandException {
+        assert original != null;
 
-        Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
-        Optional<Phone> updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
-        Optional<Telegram> updatedTelegram = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
-        Set<Remark> remarks = personToEdit.getRemarks();
-        List<Project> projects = personToEdit.getProjects();
+        // Assemble common fields
+        Name name = edits.nameOr(original.getName());
+        Optional<Phone> phone = edits.phoneOr(original.getPhone());
+        Email email = edits.emailOr(original.getEmail());
+        Optional<Telegram> telegram = edits.telegramOr(original.getTelegram());
 
-        if (personToEdit instanceof TeamMember teamMember) {
-            // person is a team member
-            if (editPersonDescriptor.getOrganisation().isPresent()) {
-                throw new CommandException(MESSAGE_NOT_PERMITTED_FOR_ROLE);
-            }
-            Committee updatedCommittee = editPersonDescriptor.getCommittee().orElse(teamMember.getCommittee());
+        var remarks = original.getRemarks();
+        var projects = original.getProjects();
 
+        // Role-specific branching
+        if (original instanceof TeamMember tm) {
+            ensureNoOrganisationForTeamMember(edits);
             return new TeamMember(
-                    updatedName, updatedCommittee, updatedPhone, updatedEmail, updatedTelegram,
-                    remarks, projects
+                    name,
+                    edits.getCommittee().orElse(tm.getCommittee()),
+                    phone, email, telegram, remarks, projects
             );
-
-        } else if (personToEdit instanceof OrgMember orgMember) {
-            // person is an organisation member
-            if (editPersonDescriptor.getCommittee().isPresent()) {
-                throw new CommandException(MESSAGE_NOT_PERMITTED_FOR_ROLE);
-            }
-            Organisation updatedOrganisation =
-                    editPersonDescriptor.getOrganisation().orElse(orgMember.getOrganisation());
-
+        }
+        if (original instanceof OrgMember om) {
+            ensureNoCommitteeForOrgMember(edits);
             return new OrgMember(
-                    updatedName, updatedOrganisation, updatedPhone, updatedEmail, updatedTelegram,
-                    remarks, projects
+                    name,
+                    edits.getOrganisation().orElse(om.getOrganisation()),
+                    phone, email, telegram, remarks, projects
             );
         }
 
-        // person is a volunteer
-        return new Volunteer(updatedName, updatedPhone, updatedEmail, updatedTelegram,
-                remarks, projects
-        );
+        // Volunteer
+        ensureNoRoleOnlyFieldsForVolunteer(edits);
+        return new Volunteer(name, phone, email, telegram, remarks, projects);
+    }
 
+    /**
+     * Ensures that {@code organisation} is not edited for a {@link TeamMember}.
+     *
+     * @throws CommandException if {@code organisation} is present
+     */
+    private static void ensureNoOrganisationForTeamMember(EditPersonDescriptor edits) throws CommandException {
+        if (edits.getOrganisation().isPresent()) {
+            throw new CommandException(MESSAGE_NOT_PERMITTED_FOR_ROLE);
+        }
+    }
+
+    /**
+     * Ensures that {@code committee} is not edited for an {@link OrgMember}.
+     *
+     * @throws CommandException if {@code committee} is present
+     */
+    private static void ensureNoCommitteeForOrgMember(EditPersonDescriptor edits) throws CommandException {
+        if (edits.getCommittee().isPresent()) {
+            throw new CommandException(MESSAGE_NOT_PERMITTED_FOR_ROLE);
+        }
+    }
+
+    /**
+     * Ensures that volunteers do not receive role-specific fields.
+     *
+     * @throws CommandException if {@code committee} or {@code organisation} is present
+     */
+    private static void ensureNoRoleOnlyFieldsForVolunteer(EditPersonDescriptor edits) throws CommandException {
+        if (edits.getCommittee().isPresent() || edits.getOrganisation().isPresent()) {
+            throw new CommandException(MESSAGE_NOT_PERMITTED_FOR_ROLE);
+        }
     }
 
     @Override
@@ -188,6 +231,18 @@ public class EditCommand extends Command {
 
         public EditPersonDescriptor() {}
 
+        /** Returns updated value if the descriptor specifies it; otherwise returns current. */
+        public Optional<Phone> phoneOr(Optional<Phone> current) { return phone != null ? phone : current; }
+
+        /** Returns updated value if the descriptor specifies it; otherwise returns current. */
+        public Optional<Telegram> telegramOr(Optional<Telegram> current) {
+            return telegram != null ? telegram : current;
+        }
+
+        public Name nameOr(Name current) { return name != null ? name : current; }
+
+        public Email emailOr(Email current) { return email != null ? email : current; }
+
         /**
          * Copy constructor.
          */
@@ -219,10 +274,6 @@ public class EditCommand extends Command {
             this.phone = phone;
         }
 
-        public Optional<Optional<Phone>> getPhone() {
-            return Optional.ofNullable(phone);
-        }
-
         public void setEmail(Email email) {
             this.email = email;
         }
@@ -231,12 +282,24 @@ public class EditCommand extends Command {
             return Optional.ofNullable(email);
         }
 
+        /** Returns true iff the descriptor explicitly includes a phone edit (present or explicit removal). */
+        public boolean hasPhoneEdit() { return phone != null; }
+
+        /** Returns the edited phone value when present; empty = explicit removal. Undefined if !hasPhoneEdit(). */
+        public Optional<Phone> editedPhone() { return phone; }
+
+        /** Returns true iff the descriptor explicitly includes a telegram edit (present or explicit removal). */
+        public boolean hasTelegramEdit() { return telegram != null; }
+
+        /**
+         * Returns the edited telegram value when present;
+         * empty = explicit removal. Undefined if !hasTelegramEdit().
+         */
+        public Optional<Telegram> editedTelegram() { return telegram; }
+
+
         public void setTelegram(Optional<Telegram> telegram) {
             this.telegram = telegram;
-        }
-
-        public Optional<Optional<Telegram>> getTelegram() {
-            return Optional.ofNullable(telegram);
         }
 
         public void setCommittee(Committee committee) {

--- a/src/main/java/loopin/projectbook/logic/commands/projectcommands/BaseProjectMemberCommand.java
+++ b/src/main/java/loopin/projectbook/logic/commands/projectcommands/BaseProjectMemberCommand.java
@@ -1,0 +1,97 @@
+package loopin.projectbook.logic.commands.projectcommands;
+
+import static java.util.Objects.requireNonNull;
+import static loopin.projectbook.logic.Messages.MESSAGE_NO_PERSON;
+import static loopin.projectbook.logic.Messages.MESSAGE_NO_PROJECT;
+import static loopin.projectbook.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static loopin.projectbook.logic.Messages.MESSAGE_AMBIGUOUS_NAME;
+
+import java.util.List;
+import java.util.Locale;
+
+import loopin.projectbook.commons.core.index.Index;
+import loopin.projectbook.logic.commands.Command;
+import loopin.projectbook.logic.commands.exceptions.CommandException;
+import loopin.projectbook.model.Model;
+import loopin.projectbook.model.person.Person;
+import loopin.projectbook.model.project.Project;
+import loopin.projectbook.model.project.ProjectName;
+
+/**
+ * Abstract base for project membership commands that need to resolve a {@link Person}
+ * either by exact (case-insensitive) name or by index in the current filtered list.
+ *
+ * Subclasses call {@link #resolveTargetPerson(Model, String, Index)} to obtain the target person
+ * using consistent error messages and behavior.
+ */
+abstract class BaseProjectMemberCommand extends Command {
+
+    /**
+     * Resolves a target person by either:
+     *   - an exact (case-insensitive) name match, if {@code name} is non-{@code null}; or
+     *   - an index into the current filtered person list, if {@code name} is {@code null}.
+     *
+     * @param model backing model; must not be {@code null}
+     * @param name case-insensitive exact name to match, or {@code null} to use {@code index}
+     * @param index index into the current filtered person list (used if {@code name} is {@code null})
+     * @return the uniquely resolved {@link Person}
+     * @throws CommandException if the name is not found or ambiguous, or if the index is out of range
+     */
+    protected final Person resolveTargetPerson(Model model, String name, Index index) throws CommandException {
+        requireNonNull(model);
+        if (name != null) {
+            return resolveByExactName(model, name);
+        }
+        List<Person> shown = model.getFilteredPersonList();
+        if (index.getZeroBased() >= shown.size()) {
+            throw new CommandException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        return shown.get(index.getZeroBased());
+    }
+
+    /**
+     * Returns the unique person whose name exactly matches {@code name} under trim + lowercasing comparison.
+     *
+     * @param model backing model; must not be {@code null}
+     * @param name person name to match (case-insensitive, exact)
+     * @return the unique matching {@link Person}
+     * @throws CommandException if none or more than one person matches
+     */
+    private Person resolveByExactName(Model model, String name) throws CommandException {
+        String needle = name.trim().toLowerCase(Locale.ROOT);
+        List<Person> pool = model.getProjectBook().getPersonList();
+        List<Person> matches = pool.stream()
+                .filter(p -> p.getName() != null
+                        && p.getName().toString().trim().toLowerCase(Locale.ROOT).equals(needle))
+                .toList();
+
+        if (matches.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_NO_PERSON, name));
+        }
+        if (matches.size() > 1) {
+            throw new CommandException(String.format(MESSAGE_AMBIGUOUS_NAME, name));
+        }
+        return matches.get(0);
+    }
+
+    /**
+     * Resolves and returns the {@link Project} identified by the given {@link ProjectName}.
+     *
+     * This helper performs a case-insensitive lookup in the model and standardizes
+     * the "project not found" error handling used by all project-membership commands.
+     * It centralizes common logic from {@link ProjectAssignCommand} and
+     * {@link ProjectRemoveCommand} to maintain consistent error messages and behavior.
+     *
+     * @param model the backing {@link Model} used to access the current project list; must not be {@code null}
+     * @param projectName the validated {@link ProjectName} to locate; must not be {@code null}
+     * @return the unique {@link Project} whose name matches {@code projectName}
+     * @throws CommandException if no project with the specified name exists
+     */
+    protected final Project resolveProjectByName(Model model, ProjectName projectName) throws CommandException {
+        requireNonNull(model);
+        requireNonNull(projectName);
+        String lookup = projectName.toString();
+        return model.findProjectByName(lookup)
+                .orElseThrow(() -> new CommandException(String.format(MESSAGE_NO_PROJECT, lookup)));
+    }
+}

--- a/src/main/java/loopin/projectbook/logic/commands/projectcommands/ProjectAssignCommand.java
+++ b/src/main/java/loopin/projectbook/logic/commands/projectcommands/ProjectAssignCommand.java
@@ -17,11 +17,16 @@ import loopin.projectbook.model.project.ProjectName;
 
 /**
  * Assigns a person to an existing project.
+ *
  * Usage:
- * {@code project assign INDEX project/PROJECT_NAME}
- * {@code project assign n/NAME project/PROJECT_NAME}
+ * {@code
+ * project assign INDEX project/PROJECT_NAME
+ * project assign n/NAME project/PROJECT_NAME
+ * }
+ *
+ * Person resolution uses {@link BaseProjectMemberCommand#resolveTargetPerson(Model, String, Index)}.
  */
-public final class ProjectAssignCommand extends Command {
+public final class ProjectAssignCommand extends BaseProjectMemberCommand {
     public static final String COMMAND_WORD = "project";
     public static final String SUBCOMMAND = "assign";
     public static final String MESSAGE_USAGE =
@@ -35,21 +40,16 @@ public final class ProjectAssignCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Assigned %s to the project %s.";
     public static final String MESSAGE_ALREADY = "%s is already in this project.";
-    public static final String MESSAGE_NO_PROJECT = "Project '%s' does not exist.";
-    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid.";
-    public static final String MESSAGE_NOT_FOUND_BY_NAME = "No person found with the name %s.";
-    public static final String MESSAGE_AMBIGUOUS_NAME = "Multiple people share the name %s.\n"
-            + "Please use index-based assignment instead.";
 
     private final Index index;
     private final String name;
     private final ProjectName projectName;
 
     /**
-     * Constructs a command to assign the person at {@code index} to the project named {@code projectName}.
+     * Creates a command to assign the person at {@code index} to the project named {@code projectName}.
      *
      * @param index index of the person in the current filtered person list
-     * @param projectName the validated project name value object
+     * @param projectName validated project name value object
      */
     public ProjectAssignCommand(Index index, ProjectName projectName) {
         this.index = index;
@@ -58,10 +58,10 @@ public final class ProjectAssignCommand extends Command {
     }
 
     /**
-     * Constructs a command to assign the person called {@code name} to the project named {@code projectName}.
+     * Creates a command to assign the person called {@code name} to the project named {@code projectName}.
      *
-     * @param name name of the person
-     * @param projectName the validated project name value object
+     * @param name exact (case-insensitive) person name
+     * @param projectName validated project name value object
      */
     public ProjectAssignCommand(String name, ProjectName projectName) {
         requireNonNull(name);
@@ -74,20 +74,9 @@ public final class ProjectAssignCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        String lookup = projectName.toString();
-        Project project = model.findProjectByName(lookup)
-                .orElseThrow(() -> new CommandException(String.format(MESSAGE_NO_PROJECT, lookup)));
+        Project project = resolveProjectByName(model, projectName);
 
-        final Person target;
-        if (name != null) {
-            target = resolveByName(model, name);
-        } else {
-            List<Person> lastShown = model.getFilteredPersonList();
-            if (index.getZeroBased() >= lastShown.size()) {
-                throw new CommandException(MESSAGE_INVALID_INDEX);
-            }
-            target = lastShown.get(index.getZeroBased());
-        }
+        Person target = resolveTargetPerson(model, name, index);
 
         if (project.hasMember(target)) {
             throw new CommandException(String.format(MESSAGE_ALREADY, target.getName()));
@@ -98,39 +87,5 @@ public final class ProjectAssignCommand extends Command {
         model.setProject(project);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, target.getName(), projectName));
-    }
-
-    /**
-     * Returns a Person whose name matches the specified {@code name}, using a case-insensitive exact match.
-     *
-     * @param model the Model containing the list of persons to search through
-     * @param name the name of the person to look up
-     * @return the unique Person whose name matches the given {@code name}
-     * @throws CommandException if no matching person is found or if multiple persons share the same name
-     */
-    private Person resolveByName(Model model, String name) throws CommandException {
-        String trimmedLowerName = name.trim().toLowerCase(Locale.ROOT);
-
-        List<Person> allPersons = model.getProjectBook().getPersonList();
-        List<Person> matches = new ArrayList<>();
-        System.out.println(allPersons);
-
-        for (Person p : allPersons) {
-            String candidate = p.getName().toString();
-            if (candidate != null && candidate.trim().toLowerCase(Locale.ROOT).equals(trimmedLowerName)) {
-                matches.add(p);
-            }
-        }
-
-        if (matches.isEmpty()) {
-            throw new CommandException(String.format(MESSAGE_NOT_FOUND_BY_NAME, trimmedLowerName));
-        }
-
-        if (matches.size() > 1) {
-            throw new CommandException(String.format(MESSAGE_AMBIGUOUS_NAME, trimmedLowerName));
-        }
-
-        return matches.get(0);
-
     }
 }

--- a/src/main/java/loopin/projectbook/logic/commands/projectcommands/ProjectDeleteCommand.java
+++ b/src/main/java/loopin/projectbook/logic/commands/projectcommands/ProjectDeleteCommand.java
@@ -1,12 +1,13 @@
 package loopin.projectbook.logic.commands.projectcommands;
 
 import static java.util.Objects.requireNonNull;
+import static loopin.projectbook.logic.Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX;
+import static loopin.projectbook.logic.Messages.MESSAGE_NO_PROJECT;
 
 import java.util.List;
 import java.util.Optional;
 
 import loopin.projectbook.commons.core.index.Index;
-import loopin.projectbook.logic.Messages;
 import loopin.projectbook.logic.commands.Command;
 import loopin.projectbook.logic.commands.CommandResult;
 import loopin.projectbook.logic.commands.exceptions.CommandException;
@@ -14,12 +15,20 @@ import loopin.projectbook.model.Model;
 import loopin.projectbook.model.project.Project;
 
 /**
- * Deletes a project either by its index in the currently displayed project list
- * or by its name.
+ * Deletes an existing project by index in the current filtered list, or by exact (case-insensitive) name.
+ *
+ * Usage:
+ * {@code
+ * project delete INDEX
+ * project delete n/NAME
+ * }
+ *
+ * Cascading cleanup (e.g., removing back-references from members) should be handled by
+ * {@link Model#deleteProject(Project)}.
  */
 public class ProjectDeleteCommand extends Command {
 
-    public static final String COMMAND_WORD = "project delete";
+    public static final String COMMAND_WORD = "project";
     public static final String SUBCOMMAND = "delete";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a project.\n"
             + "Formats:\n"
@@ -34,18 +43,23 @@ public class ProjectDeleteCommand extends Command {
     private final Index targetIndex;
     private final String targetName;
 
-    /** Deletes by index. */
+    /** Creates a delete-by-index command. */
     public ProjectDeleteCommand(Index targetIndex) {
         requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
         this.targetName = null;
     }
 
-    /** Deletes by name. */
+    /** Creates a delete-by-name command. */
     public ProjectDeleteCommand(String targetName) {
         requireNonNull(targetName);
+        String trimmed = targetName.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Project name cannot be blank.");
+        }
+
         this.targetIndex = null;
-        this.targetName = targetName;
+        this.targetName = trimmed;
     }
 
     @Override
@@ -55,7 +69,7 @@ public class ProjectDeleteCommand extends Command {
         if (targetIndex != null) {
             List<Project> lastShownList = model.getFilteredProjectList();
             if (targetIndex.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+                throw new CommandException(MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
             }
             Project toDelete = lastShownList.get(targetIndex.getZeroBased());
             model.deleteProject(toDelete);
@@ -64,7 +78,7 @@ public class ProjectDeleteCommand extends Command {
 
         Optional<Project> match = model.findProjectByName(targetName);
         if (match.isEmpty()) {
-            throw new CommandException(String.format(Messages.MESSAGE_PROJECT_NOT_FOUND_BY_NAME, targetName));
+            throw new CommandException(String.format(MESSAGE_NO_PROJECT, targetName));
         }
         Project toDelete = match.get();
         model.deleteProject(toDelete);

--- a/src/main/java/loopin/projectbook/logic/commands/projectcommands/ProjectRemoveCommand.java
+++ b/src/main/java/loopin/projectbook/logic/commands/projectcommands/ProjectRemoveCommand.java
@@ -16,12 +16,17 @@ import loopin.projectbook.model.project.Project;
 import loopin.projectbook.model.project.ProjectName;
 
 /**
- * Removes a person (by index in the current person list) from an existing project.
+ * Removes a person from an existing project.
+ *
  * Usage:
- * {@code project remove INDEX project/PROJECT_NAME}
- * {@code project remove n/NAME project/PROJECT_NAME}
+ * {@code
+ * project remove INDEX project/PROJECT_NAME
+ * project remove n/NAME project/PROJECT_NAME
+ * }
+ *
+ * Person resolution uses {@link BaseProjectMemberCommand#resolveTargetPerson(Model, String, Index)}.
  */
-public final class ProjectRemoveCommand extends Command {
+public final class ProjectRemoveCommand extends BaseProjectMemberCommand {
     public static final String COMMAND_WORD = "project";
     public static final String SUBCOMMAND = "remove";
     public static final String MESSAGE_USAGE =
@@ -35,21 +40,16 @@ public final class ProjectRemoveCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Removed %s from the project %s.";
     public static final String MESSAGE_NOT_IN = "%s is not in this project.";
-    public static final String MESSAGE_NO_PROJECT = "Project '%s' does not exist.";
-    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid.";
-    public static final String MESSAGE_NOT_FOUND_BY_NAME = "No person found with the name %s.";
-    public static final String MESSAGE_AMBIGUOUS_NAME = "Multiple people share the name %s.\n"
-            + "Please use index-based assignment instead.";
 
     private final Index index;
     private final String name;
     private final ProjectName projectName;
 
     /**
-     * Constructs a command to remove the person at {@code index} from the project named {@code projectName}.
+     * Creates a command to remove the person at {@code index} from the project named {@code projectName}.
      *
      * @param index index of the person in the current filtered person list
-     * @param projectName the validated project name value object
+     * @param projectName validated project name value object
      */
     public ProjectRemoveCommand(Index index, ProjectName projectName) {
         this.index = index;
@@ -58,10 +58,10 @@ public final class ProjectRemoveCommand extends Command {
     }
 
     /**
-     * Constructs a command to remove the person called {@code name} from the project named {@code projectName}.
+     * Creates a command to remove the person called {@code name} from the project named {@code projectName}.
      *
-     * @param name name of the person
-     * @param projectName the validated project name value object
+     * @param name exact (case-insensitive) person name
+     * @param projectName validated project name value object
      */
     public ProjectRemoveCommand(String name, ProjectName projectName) {
         requireNonNull(name);
@@ -74,20 +74,9 @@ public final class ProjectRemoveCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        String lookup = projectName.toString();
-        Project project = model.findProjectByName(lookup)
-                .orElseThrow(() -> new CommandException(String.format(MESSAGE_NO_PROJECT, lookup)));
+        Project project = resolveProjectByName(model, projectName);
 
-        final Person target;
-        if (name != null) {
-            target = resolveByName(model, name);
-        } else {
-            List<Person> lastShown = model.getFilteredPersonList();
-            if (index.getZeroBased() >= lastShown.size()) {
-                throw new CommandException(MESSAGE_INVALID_INDEX);
-            }
-            target = lastShown.get(index.getZeroBased());
-        }
+        Person target = resolveTargetPerson(model, name, index);
 
         if (!project.hasMember(target)) {
             throw new CommandException(String.format(MESSAGE_NOT_IN, target.getName()));
@@ -97,39 +86,5 @@ public final class ProjectRemoveCommand extends Command {
         model.setProject(project);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, target.getName(), projectName));
-    }
-
-    /**
-     * Returns a Person whose name matches the specified {@code name}, using a case-insensitive exact match.
-     *
-     * @param model the Model containing the list of persons to search through
-     * @param name the name of the person to look up
-     * @return the unique Person whose name matches the given {@code name}
-     * @throws CommandException if no matching person is found or if multiple persons share the same name
-     */
-    private Person resolveByName(Model model, String name) throws CommandException {
-        String trimmedLowerName = name.trim().toLowerCase(Locale.ROOT);
-
-        List<Person> allPersons = model.getProjectBook().getPersonList();
-        List<Person> matches = new ArrayList<>();
-        System.out.println(allPersons);
-
-        for (Person p : allPersons) {
-            String candidate = p.getName().toString();
-            if (candidate != null && candidate.trim().toLowerCase(Locale.ROOT).equals(trimmedLowerName)) {
-                matches.add(p);
-            }
-        }
-
-        if (matches.isEmpty()) {
-            throw new CommandException(String.format(MESSAGE_NOT_FOUND_BY_NAME, trimmedLowerName));
-        }
-
-        if (matches.size() > 1) {
-            throw new CommandException(String.format(MESSAGE_AMBIGUOUS_NAME, trimmedLowerName));
-        }
-
-        return matches.get(0);
-
     }
 }

--- a/src/main/java/loopin/projectbook/logic/parser/project/ProjectRemoveCommandParser.java
+++ b/src/main/java/loopin/projectbook/logic/parser/project/ProjectRemoveCommandParser.java
@@ -13,54 +13,50 @@ import loopin.projectbook.logic.parser.exceptions.ParseException;
 import loopin.projectbook.model.project.ProjectName;
 
 /**
- * Parses input arguments and creates a new {@link ProjectRemoveCommand} object.
+ * Parses input arguments and creates a new {@link ProjectRemoveCommand}.
  *
- * Supported formats:
- * {@code INDEX project/PROJECT_NAME}
- * {@code n/NAME project/PROJECT_NAME}
+ * Supported forms:
+ *   INDEX project/PROJECT_NAME
+ *   n/NAME project/PROJECT_NAME
  */
 public final class ProjectRemoveCommandParser implements Parser<ProjectRemoveCommand> {
 
     @Override
     public ProjectRemoveCommand parse(String args) throws ParseException {
-        final String normalized = " " + args.trim();
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(normalized, PREFIX_NAME, PREFIX_PROJECT);
+        final String trimmed = args == null ? "" : args.trim();
+        final ArgumentMultimap map = ArgumentTokenizer.tokenize(" " + trimmed, PREFIX_NAME, PREFIX_PROJECT);
 
-        if (args.trim().startsWith(PREFIX_NAME.getPrefix())) {
-            //name-based assignment
-            String nameValue = argMultimap.getValue(PREFIX_NAME)
-                    .orElseThrow(() -> new ParseException(ProjectRemoveCommand.MESSAGE_USAGE));
-            ProjectName projectName = argMultimap.getValue(PREFIX_PROJECT)
-                    .map(n -> {
-                        try {
-                            return ParserUtil.parseProjectName(n);
-                        } catch (ParseException e) {
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    .orElseThrow(() -> new ParseException(ProjectRemoveCommand.MESSAGE_USAGE));
+        final ProjectName projectName = requireProjectName(map, ProjectRemoveCommand.MESSAGE_USAGE);
 
-            return new ProjectRemoveCommand(nameValue.trim(), projectName);
+        if (isNameMode(trimmed)) {
+            final String name = map.getValue(PREFIX_NAME)
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .orElseThrow(() -> new ParseException(ProjectRemoveCommand.MESSAGE_USAGE));
+            return new ProjectRemoveCommand(name, projectName);
         }
 
-        String preamble = argMultimap.getPreamble().trim();
-        ProjectName projectName = argMultimap.getValue(PREFIX_PROJECT)
-                .map(n -> {
-                    try {
-                        return ParserUtil.parseProjectName(n);
-                    } catch (ParseException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .orElseThrow(() -> new ParseException(ProjectRemoveCommand.MESSAGE_USAGE));
-
-        if (!preamble.isEmpty()) {
-            // index-based assignment
-            Index index = ParserUtil.parseIndex(preamble);
-            return new ProjectRemoveCommand(index, projectName);
-        }
-
-        Index index = ParserUtil.parseIndex(preamble);
+        final Index index = parseIndexFromPreamble(map, ProjectRemoveCommand.MESSAGE_USAGE);
         return new ProjectRemoveCommand(index, projectName);
+    }
+
+    // ---- helpers ----
+
+    private static boolean isNameMode(String trimmedArgs) {
+        return trimmedArgs.startsWith(PREFIX_NAME.getPrefix());
+    }
+
+    private static ProjectName requireProjectName(ArgumentMultimap map, String usage) throws ParseException {
+        String raw = map.getValue(PREFIX_PROJECT)
+                .orElseThrow(() -> new ParseException(usage));
+        return ParserUtil.parseProjectName(raw);
+    }
+
+    private static Index parseIndexFromPreamble(ArgumentMultimap map, String usage) throws ParseException {
+        String preamble = map.getPreamble().trim();
+        if (preamble.isEmpty()) {
+            throw new ParseException(usage);
+        }
+        return ParserUtil.parseIndex(preamble);
     }
 }


### PR DESCRIPTION
Key Changes
- Introduced BaseProjectMemberCommand – unified logic for resolving persons and projects by name/index.
- Refactored EditCommand – modular createEditedPerson() with clear SLAP steps (common fields → role constraints → subclass creation).
- Enhanced EditPersonDescriptor – added nameOr, emailOr, phoneOr, telegramOr to hide nested Optional logic.
- Simplified Parsers – replaced complex lambdas with clear conditional parsing; consistent ParseException handling.
- Improved UniqueProjectList – centralized normalization, added findByName() and removeByName() for cleaner lookup.
- Updated ProjectAssignCommand & ProjectRemoveCommand – now extend base class to eliminate duplicate resolution logic.
- Hardened ProjectDeleteCommand – uniform name/index deletion flow with clear validation.
- Expanded Javadoc & Defensive Checks – consistent usage examples, role-specific constraints, and error messages.

Outcome
- Clearer class responsibilities and shorter methods (SLAP applied).
- Reduced code duplication and improved maintainability.
- Consistent user-facing behavior across assign/remove/delete/edit workflows.
- Stronger type-safety and error handling in parsing and command execution paths.